### PR TITLE
Version 0.3.6

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: packagedocs
 Title: Build Webstite of Package Documentation
-Version: 0.3.5
-Date: 2015-12-10
+Version: 0.3.6
+Date: 2016-04-13
 Authors@R: "Ryan Hafen <rhafen@gmail.com> [aut, cre]"
 Description: Use rmarkdown to build a package documentation site.
 Depends:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,7 @@
+Version 0.3.6
+----------------------------------------------------------------------
+
+FIXES
+
+- In `rd_template()`, if a function or alias had the same name as the package, it was being excluded from the documentation. This is now fixed.
+

--- a/R/rd_template.R
+++ b/R/rd_template.R
@@ -53,8 +53,16 @@ rd_template <- function(package_name, code_path, rd_index = NULL, exclude = NULL
   # want to be able to list all aliases (more functions can exist than .Rd files)
   nms <- unname(unlist(lapply(db, tools:::.Rd_get_metadata, "alias")))
 
-  exclude <- c(exclude, package_name)
-  message("ignoring: ", paste(exclude, collapse = ", "))
+  # Under what conditions do we add `package_name` to exclude?
+  # Only of there doesn't exist a function or alias with the same name as the package
+  if(!(package_name %in% nms)){
+    exclude <- unique(c(exclude, package_name))
+  }
+
+  if(!is.null(exclude)){
+    message("ignoring: ", paste(exclude, collapse = ", "))      
+  }
+
   nms <- setdiff(nms, exclude)
 
   if(!is.null(rd_index)) {


### PR DESCRIPTION
`rd_template()` was excluding functions or aliases with the same name as the package. This is now fixed.
