### PR TITLE
Fix code for devtools 2.1.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,8 +17,8 @@ BugReports: https://github.com/hafen/packagedocs/issues
 LazyData: true
 Imports: crayon, devtools, digest, evaluate, highlight, htmltools,
         lazyrmd (>= 0.2.0), magrittr, rmarkdown, stringr, tools,
-        whisker, yaml
+        usethis, whisker, yaml
 Suggests: testthat
-RoxygenNote: 5.0.1
+RoxygenNote: 6.1.1
 VignetteBuilder: packagedocs
 NeedsCompilation: no

--- a/R/init.R
+++ b/R/init.R
@@ -65,7 +65,7 @@ init_vignettes <- function(
   devtools_use_directory("vignettes", pkg = pkg)
   devtools_use_git_ignore("inst/doc", pkg = pkg)
   devtools_use_git_ignore("_gh-pages", pkg = pkg)
-  devtools::use_build_ignore("_gh-pages", pkg = pkg)
+  usethis::use_build_ignore("_gh-pages", pkg = pkg)
 
 
   rd_info <- as_sd_package(code_path)

--- a/R/travis.R
+++ b/R/travis.R
@@ -5,7 +5,7 @@
 #'
 #' @param pkg location of package
 #' @param add boolean that determines if all items should be added to the travis yaml file or printed on screen
-#' @param browse passed onto \code{devtools::\link{use_travis}}
+#' @param browse passed onto \code{usethis::\link{use_travis}}
 #' @export
 use_travis <- function(pkg = ".", add = TRUE, browse = interactive()) {
   if (!isTRUE(add)) {
@@ -34,7 +34,9 @@ use_travis <- function(pkg = ".", add = TRUE, browse = interactive()) {
   travis_file <- file.path(pkg$path, ".travis.yml")
 
   if (!file.exists(travis_file)) {
-    devtools::use_travis(pkg, browse = browse)
+    usethis::with_project(pkg$path,
+      usethis::use_travis(browse = browse)
+    )
   }
 
   travis_yaml <- yaml::yaml.load_file(travis_file)

--- a/man/use_travis.Rd
+++ b/man/use_travis.Rd
@@ -11,7 +11,7 @@ use_travis(pkg = ".", add = TRUE, browse = interactive())
 
 \item{add}{boolean that determines if all items should be added to the travis yaml file or printed on screen}
 
-\item{browse}{passed onto \code{devtools::\link{use_travis}}}
+\item{browse}{passed onto \code{usethis::\link{use_travis}}}
 }
 \description{
 Use Travis CI


### PR DESCRIPTION
devtools 2.1.0 removes the previously deprecated `use_*()` functions
now implemented the usethis package, which causes R CMD check notes
fixed by these changes.

Note looking at the code of packagedocs it uses a lot of un-exported functions that will be or have been removed, the packagedocs code is unlikely to actually work as written, but this will at least make the check pass cleanly.